### PR TITLE
Allow query-string parameters in INSTALL_URL and parse it in `install_app`

### DIFF
--- a/scripts/sommelier
+++ b/scripts/sommelier
@@ -120,6 +120,9 @@ install_app() {
 
   # Download installer if requested.
   if [[ -n "${INSTALL_URL:-}" ]]; then
+    # If we've been given an installer URL derive the filename
+    INSTALL_EXE="$(basename "${INSTALL_URL//\?*/}")"
+
     wget "${INSTALL_URL}" -O "${TMPDIR}/${INSTALL_EXE}" 2>&1 | \
     perl -p -e '$| = 1; s/^.* +([0-9]+%) +([0-9,.]+[GMKB]) +([0-9hms,.]+).*$/\1\n# Downloading... \2 (\3)/' | \
     yad --progress --title="Downloading ${INSTALL_EXE}" --width=400 --center --no-buttons --auto-close --auto-kill --on-top --no-escape
@@ -220,11 +223,6 @@ start_app() {
 
 if [[ -z "${WINEDEBUG:-}" ]]; then
   export WINEDEBUG="-all"
-fi
-
-# If we've been given and installer URL derive the filename
-if [[ -n "${INSTALL_URL:-}" ]]; then
-  INSTALL_EXE="$(basename "${INSTALL_URL}")"
 fi
 
 


### PR DESCRIPTION
* Strip everything after a `?` in the `INSTALL_URL` when computing the `INSTALL_EXE` to allow for URLs that include query-string parameters.
* Move the parsing of `INSTALL_URL` in order to extract `INSTALL_EXE` into the `install_app` function - it isn't used anywhere else, and this allows the pre-install hook to change `INSTALL_URL` before it is parsed into `INSTALL_EXE`.