### PR TITLE
FIX: installing winetricks verbs early

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ See the following snaps for complete examples of how to use sommelier-core.
 
 * [PhotoScape snap](https://github.com/snapcrafters/photoscape)
 * [Bridge Designer snap](https://github.com/snapcrafters/bridge-designer)
-* [TrackMania Nations Forever snap](https://github.com/galgalesh/tmnationsforever)
+* [TrackMania Nations Forever snap](https://github.com/snapcrafters/tmnationsforever)
 
 ### Variables
 

--- a/scripts/sommelier
+++ b/scripts/sommelier
@@ -111,12 +111,6 @@ init_wine() {
 install_app() {
   echo "Installing application.."
 
-  # Run pre-install hook
-  if [[ -f "$SNAP/sommelier/hooks/pre-install" ]]; then
-    echo "Running hook '$SNAP/sommelier/hooks/pre-install'"
-    . "$SNAP/sommelier/hooks/pre-install"
-  fi
-
   ORIGINAL_LINKS=( $(xdg-user-dir DESKTOP)/*.lnk )
 
   # Install additional requirements via winetricks
@@ -125,6 +119,12 @@ install_app() {
       "${WINETRICKS}" --unattended "${TRICK}" | \
       yad --progress --title="Installing ${TRICK}" --progress-text= --width=400 --center --no-buttons --auto-close --auto-kill --on-top --pulsate
     done
+  fi
+
+  # Run pre-install hook
+  if [[ -f "$SNAP/sommelier/hooks/pre-install" ]]; then
+    echo "Running hook '$SNAP/sommelier/hooks/pre-install'"
+    . "$SNAP/sommelier/hooks/pre-install"
   fi
 
   # Download installer if requested.


### PR DESCRIPTION
Since some installers required verbs in wineprefix to work properly.

This also fixes TRICKS envar to work properly otherwise had to add verbs manually to pre-install script to fix installer requirements.