### PR TITLE
Fix for nvidia drivers on Ubuntu 21.10 and other very modern systems

### DIFF
--- a/scripts/sommelier
+++ b/scripts/sommelier
@@ -289,6 +289,9 @@ if [[ ! -d "$WINE_PLATFORM" ]]; then
   fi
 fi
 
+# Fix for nvidia drivers on Ubuntu 21.10 and other very modern systems (part 1 of 2)
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH#$SNAP_LIBRARY_PATH:}"
+
 append_dir PATH "$WINE_PLATFORM/bin"
 
 # Note: Technically, we should be able to just use the `wine` command and get
@@ -393,6 +396,10 @@ export WINEDLLOVERRIDES="${WINEDLLOVERRIDES:-};winemenubuilder.exe=d"
 if [[ ! -f "${WINEPREFIX}/drive_c/windows/system.ini"  || "$(cat "$SNAP_USER_COMMON/.last_snap_revision" 2>/dev/null)" != "$SNAP_REVISION" ]]; then
   init_wine
 fi
+
+
+# Fix for nvidia drivers on Ubuntu 21.10 and other very modern systems (part 2 of 2)
+append_dir LD_LIBRARY_PATH "${SNAP_LIBRARY_PATH}"
 
 
 #####################################


### PR DESCRIPTION
The `snapcraft-runner` script that snapcraft uses to launch apps, including sommelier-based apps, prepends `$SNAP_LIBRARY_PATH` onto `$LD_LIBRARY_PATH`. This actually needs to be addpended (on the end, not the beginning), so that the drivers are found last.

Ask @flexiondotorg for the gory details, as this is their fix discovered for the OBS-Studio snap that I've adapted ;-)
