### PR TITLE
Add additional application category descriptions to example snaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ Pros:
 
 See the following snaps for complete examples of how to use sommelier-core.
 
-* [PhotoScape snap](https://github.com/snapcrafters/photoscape)
-* [Bridge Designer snap](https://github.com/snapcrafters/bridge-designer)
-* [TrackMania Nations Forever snap](https://github.com/snapcrafters/tmnationsforever)
+* [PhotoScape snap](https://github.com/snapcrafters/photoscape)  
+  Re-distributable installer bundled within packaging source
+* [Bridge Designer snap](https://github.com/snapcrafters/bridge-designer)  
+  Re-distributable installer bundled within packaging source
+* [TrackMania Nations Forever snap](https://github.com/snapcrafters/tmnationsforever)  
+  Non re-distributable installer fetched during snap runtime
 
 ### Variables
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ See the following snaps for complete examples of how to use sommelier-core.
   Re-distributable installer bundled within packaging source
 * [TrackMania Nations Forever snap](https://github.com/snapcrafters/tmnationsforever)  
   Non re-distributable installer fetched during snap runtime
+* [XNote Stopwatch snap](https://github.com/brlin-tw/xnote-stopwatch-snap)  
+  Portable application, non re-distributable executable fetched during snap
+  runtime
 
 ### Variables
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ See the following snaps for complete examples of how to use sommelier-core.
 * [XNote Stopwatch snap](https://github.com/brlin-tw/xnote-stopwatch-snap)  
   Portable application, non re-distributable executable fetched during snap
   runtime
+* [GRC's DNS Benchmark snap](https://github.com/brlin-tw/dnsbench-snap)  
+  Portable application, re-distributable executable fetched during snap buildtime
 
 ### Variables
 


### PR DESCRIPTION
This patch adds application category descriptions to the example snaps section so that packagers may refer to the recipe that closely resembles to their target application.

Another example application is also added that demonstrates snapping portable, non-redistributable applications.