### PR TITLE
makefile: check `SOMMELIER_NO_THEME` when adding wine theme to consumer snap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LIB_DIR	     := $(DESTDIR)/lib
 BINDTEXTDOMAIN  := bindtextdomain.so
 HW_PLATFORM     := $(shell uname --hardware-platform)
 ARCH_32         := i386-linux-gnu
+SM_NO_THEME     := $(shell grep SOMMELIER_NO_THEME ${SNAPCRAFT_PROJECT_DIR}/snap/snapcraft.yaml | cut -d':' -f2 | sed 's/^ *//' || true)
 
 build:
 	# Build the 32-bit version of the bindtextdomain patch. This patch
@@ -37,8 +38,10 @@ install:
 	install -D -m644 config/noto-sans-cjk-sc.reg "$(DESTDIR)"/sommelier/config/noto-sans-cjk-sc.reg
 
 	# Themes
+ifeq ($(SM_NO_THEME), 0)
 	install -D -m644 themes/light/light.msstyles "$(DESTDIR)"/sommelier/themes/light/light.msstyles
 	install -D -m644 themes/light/light.reg "$(DESTDIR)"/sommelier/themes/light/light.reg
+endif
 
 	# bindtextdomain patch
 ifeq ($(HW_PLATFORM), x86_64)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ See the following snaps for complete examples of how to use sommelier-core.
 * `WINEDLLOVERRIDES`: Override DLL loading behavior: configure Wine to choose between native and builtin DLLs. See [DLL Overrides](https://wiki.winehq.org/Wine_User%27s_Guide#DLL_Overrides) and [WINEDLLOVERRIDES](https://wiki.winehq.org/Wine_User%27s_Guide#WINEDLLOVERRIDES.3DDLL_Overrides) docs for more information. Example: `"mscoree,mshtml="`
 * `WINEESYNC`: set to `1` to enable esync. This can increase performance for some games, especially ones that rely heavily on the CPU. See [esync docs](https://github.com/zfigura/wine/blob/esync/README.esync) for more information.
 * `WINEARCH`: Wine will start an 64-bit environment by default. This runs both 32-bit and 64-bit Windows binaries. Some 32-bit applications, however, have issues when you run them in 64-bit Wine. For these applications, set `WINEARCH` to `win32` to use a 32-bit-only environment.
-* `SOMMELIER_NO_THEME`: Use this variable to disable the theme. Some Java 1.6 applications crash when you apply a theme.
+* `SOMMELIER_NO_THEME`: Use this variable to disable the theme. Some Java 1.6 applications crash when you apply a theme. This should be added with value `1` in consumer snaps that are using WINE `9.x` and above.
 * `SOMMELIER_KEEP_CWD`: Use this variable when sommelier should not change the working directory before executing the app. This is useful if your app can take filenames as arguments and you want relative filenames to work. Note: some Windows apps only work when the working directory is their application directory.
 
 ## Compatibility


### PR DESCRIPTION
Currently sommelier adds WINE light theme to all consumer snaps and with new changes that were backported in https://github.com/snapcrafters/sommelier-core/pull/43 theme is slightly larger that also increases snap size.

So when consumer snap have this defined. 

snapcraft.yaml
```
environment:
  SOMMELIER_NO_THEME: "1"   # WINE theme files are not added to consumer snap otherwise these are added.
```
Previously with that env sommelier just didn't apply theme but theme files were still present in consumer snaps.

With WINE 9.x and above this theme is not required be reapplied b/c it is currently the default theme already.