### PR TITLE
makefile: fixup regression in `sm-no-theme`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIB_DIR	     := $(DESTDIR)/lib
 BINDTEXTDOMAIN  := bindtextdomain.so
 HW_PLATFORM     := $(shell uname --hardware-platform)
 ARCH_32         := i386-linux-gnu
-SM_NO_THEME     := $(shell grep SOMMELIER_NO_THEME ${SNAPCRAFT_PROJECT_DIR}/snap/snapcraft.yaml | cut -d':' -f2 | sed 's/^ *//' || true)
+SM_NO_THEME     := $(shell grep SOMMELIER_NO_THEME ${SNAPCRAFT_PROJECT_DIR}/snap/snapcraft.yaml | cut -d':' -f2 | sed 's/^ *//;s/"//g' || true)
 
 build:
 	# Build the 32-bit version of the bindtextdomain patch. This patch
@@ -38,7 +38,7 @@ install:
 	install -D -m644 config/noto-sans-cjk-sc.reg "$(DESTDIR)"/sommelier/config/noto-sans-cjk-sc.reg
 
 	# Themes
-ifeq ($(SM_NO_THEME), 0)
+ifneq ($(SM_NO_THEME), 1)
 	install -D -m644 themes/light/light.msstyles "$(DESTDIR)"/sommelier/themes/light/light.msstyles
 	install -D -m644 themes/light/light.reg "$(DESTDIR)"/sommelier/themes/light/light.reg
 endif


### PR DESCRIPTION
Tested this change in consumer snap

without `SOMMELIER_NO_THEME` adds theme files

`SOMMELIER_NO_THEME: "1"` does not adds theme files

`SOMMELIER_NO_THEME: "0"` adds theme files
